### PR TITLE
Note should be the fall-back if none of the other tags are present.

### DIFF
--- a/src/parsers/genbank.ts
+++ b/src/parsers/genbank.ts
@@ -2,7 +2,7 @@ import { Annotation } from "..";
 import { complement, guessType } from "../utils";
 
 // a list of recognized types that would constitute an annotation name
-const tagNameSet = new Set(["gene", "product", "note", "db_xref", "protein_id", "label", "lab_host", "locus_tag"]);
+const tagNameSet = new Set(["gene", "product", "db_xref", "protein_id", "label", "lab_host", "locus_tag", "note"]);
 
 // a list of tags that could represent colors
 const tagColorSet = new Set(["ApEinfo_fwdcolor", "ApEinfo_revcolor", "loom_color"]);


### PR DESCRIPTION
It's more intuitive that e.g. the /label is naming the annotation than the /note.